### PR TITLE
修正 Mirai端无法向Bukkit端同步信息

### DIFF
--- a/src/main/java/top/ncserver/chatsync/V2/MsgTools.java
+++ b/src/main/java/top/ncserver/chatsync/V2/MsgTools.java
@@ -50,7 +50,7 @@ public class MsgTools {
                 QQsendMsg(event.getGroup().getId(),"消息同步已绑定到此群");
 
             } else if (!ClientManager.aioSessionIdToClient.isEmpty()) {
-                if (ClientManager.groupIdToClient.containsKey(event.getGroup().getId())) {
+                if (event.getGroup().getId() == Config.INSTANCE.getGroupID() || ClientManager.groupIdToClient.containsKey(event.getGroup().getId())) {
                     if (Config.INSTANCE.getUnconditionalAutoSync() || event.getMessage().contentToString().startsWith(Config.INSTANCE.getAutoSyncPrefix())) {
                         Map<String, Object> msg1 = new HashMap<>();
                         String msgString = event.getMessage().contentToString();
@@ -364,6 +364,9 @@ public class MsgTools {
             for (ClientManager.ClientInfo clientInfo : ClientManager.groupIdToClient.get(0L)) {
                 AioMsgSend(msg, clientInfo);
             }
+        }
+        if (ClientManager.groupIdToClient.get(groupId) == null) {
+            return;
         }
         for (ClientManager.ClientInfo clientInfo : ClientManager.groupIdToClient.get(groupId)) {
             AioMsgSend(msg, clientInfo);


### PR DESCRIPTION
1. `ClientManager.groupIdToClient` 通常只包含一个 Key 为 `0L` 的元素，而在绑定群聊默认的情况下，多数时候 `ClientManager.groupIdToClient.containsKey(event.getGroup().getId())` 均会返回 `false`。而通过直接与配置文件比较群号（`event.getGroup().getId() == Config.INSTANCE.getGroupID()`）能有效规避这一点。
2. `ClientManager.groupIdToClient.get(groupId)` 有时候为 `null`，遍历时会抛 `NullPointerException`。